### PR TITLE
Fix bug in Tours on Android 4.4. #30

### DIFF
--- a/assets/tour/intro_template.html
+++ b/assets/tour/intro_template.html
@@ -37,7 +37,7 @@ ul li {
 </head>
 <body>
 _BODY-BEFORE-BUTTON_
-<p class="select_start"><a id="startbutton" href="select_start"><img id="startimage" src="file:///android_asset/tour/select_start_normal.png" width="302px" height="48px" /></a></p>
+<p class="select_start"><a id="startbutton" href="mitmobile2:select_start"><img id="startimage" src="file:///android_asset/tour/select_start_normal.png" width="302px" height="48px" /></a></p>
 _BODY-AFTER-BUTTON_
 </body>
 <script type="text/javascript" charset="utf-8">

--- a/src/edu/mit/mitmobile2/tour/TourIntroductionActivity.java
+++ b/src/edu/mit/mitmobile2/tour/TourIntroductionActivity.java
@@ -36,7 +36,7 @@ public class TourIntroductionActivity extends NewModuleActivity {
 		webView.setWebViewClient(new WebViewClient() {
 			@Override
 			public boolean shouldOverrideUrlLoading(WebView view, String url) {
-				if(url.equals("select_start")) {
+				if(url.equals("mitmobile2:select_start")) {
 					showMap();
 				} else {
 					CommonActions.viewURL(TourIntroductionActivity.this, url);


### PR DESCRIPTION
If you download MIT Mobile 2.5.2, run it on say a Nexus 5 running Android 4.4.4, bring up Tours, and tap "Select a starting point", the result is a white screen and not a tour map. This fixes that.

Only tested on a Nexus 5 running 4.4.4 so far.
