### PR TITLE
Fix stop subtitle in action bar and indexing error in shuttle route

### DIFF
--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/MapFragmentCallback.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/MapFragmentCallback.java
@@ -3,4 +3,5 @@ package edu.mit.mitmobile2.shuttles;
 public interface MapFragmentCallback {
     void setActionBarTitle(String title);
 
+    void setActionBarSubtitle(String subtitle);
 }

--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleRouteActivity.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleRouteActivity.java
@@ -1,11 +1,10 @@
 package edu.mit.mitmobile2.shuttles;
 
-import edu.mit.mitmobile2.shuttles.fragment.ShuttleRouteFragment;
-
 import android.os.Bundle;
 
 import edu.mit.mitmobile2.MITActivity;
 import edu.mit.mitmobile2.R;
+import edu.mit.mitmobile2.shuttles.fragment.ShuttleRouteFragment;
 
 public class ShuttleRouteActivity extends MITActivity implements MapFragmentCallback {
 
@@ -31,5 +30,10 @@ public class ShuttleRouteActivity extends MITActivity implements MapFragmentCall
     @Override
     public void setActionBarTitle(String title) {
         setTitle(title);
+    }
+
+    @Override
+    public void setActionBarSubtitle(String subtitle) {
+        getSupportActionBar().setSubtitle(subtitle);
     }
 }

--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleStopActivity.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleStopActivity.java
@@ -32,4 +32,9 @@ public class ShuttleStopActivity extends MITActivity implements MapFragmentCallb
     public void setActionBarTitle(String title) {
         setTitle(title);
     }
+
+    @Override
+    public void setActionBarSubtitle(String subtitle) {
+        getSupportActionBar().setSubtitle(subtitle);
+    }
 }

--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleStopViewPagerFragment.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/ShuttleStopViewPagerFragment.java
@@ -4,7 +4,6 @@ import android.app.Fragment;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.app.ActionBarActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -76,8 +75,6 @@ public class ShuttleStopViewPagerFragment extends Fragment {
             routesCursor.moveToNext();
         }
         cursor.close();
-
-        ((ActionBarActivity) getActivity()).getSupportActionBar().setSubtitle(stop.getTitle());
 
         predictionsAdapter = new ShuttleStopPredictionsAdapter(getActivity(), stop.getPredictions());
         intersectingAdapter = new ShuttleStopIntersectingAdapter(getActivity(), intersectingRoutes);

--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/fragment/ShuttleRouteFragment.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/fragment/ShuttleRouteFragment.java
@@ -131,7 +131,7 @@ public class ShuttleRouteFragment extends MitMapFragment implements GoogleMap.In
 
     @Override
     protected void listItemClicked(int position) {
-        MITShuttleStopWrapper stop = adapter.getItem(position);
+        MITShuttleStopWrapper stop = adapter.getItem(position - 1);
         Intent intent = new Intent(getActivity(), ShuttleStopActivity.class);
         intent.putExtra(Constants.ROUTE_ID_KEY, routeId);
         intent.putExtra(Constants.STOP_ID_KEY, stop.getId());

--- a/app/src/main/java/edu/mit/mitmobile2/shuttles/fragment/ShuttleStopFragment.java
+++ b/app/src/main/java/edu/mit/mitmobile2/shuttles/fragment/ShuttleStopFragment.java
@@ -70,6 +70,24 @@ public class ShuttleStopFragment extends MitMapFragment {
         stopViewPagerAdapter = new ShuttleStopViewPagerAdapter(getFragmentManager(), routeId, stopIds);
 
         predictionViewPager.setAdapter(stopViewPagerAdapter);
+        predictionViewPager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                callback.setActionBarSubtitle(stops.get(position).getTitle());
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+
+            }
+        });
+        int startPosition = getStartPosition();
+        callback.setActionBarSubtitle(stops.get(startPosition).getTitle());
         predictionViewPager.setCurrentItem(getStartPosition());
 
         addTransparentView(transparentView);


### PR DESCRIPTION
Should fix the three issues we discussed this morning: the crash on selecting the last stop from the route screen, the stop subtitle not updating correctly on swipe and the stop subtitle being off when selecting one from the route screen.
